### PR TITLE
'os.path.expanduser' func create the temp dir question

### DIFF
--- a/MyQR/myqr.py
+++ b/MyQR/myqr.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import tempfile
 import os
 from MyQR.mylibs import theqrmodule
 from PIL import Image
@@ -84,8 +85,9 @@ def run(words, version=1, level='H', picture=None, colorized=False, contrast=1.0
         qr_name = os.path.join(save_dir, os.path.splitext(os.path.basename(bg_name))[0] + '_qrcode.png') if not save_name else os.path.join(save_dir, save_name)
         qr.resize((qr.size[0]*3, qr.size[1]*3)).save(qr_name)
         return qr_name
-
-    tempdir = os.path.join(os.path.expanduser('~'), '.myqr')
+    
+    
+    tempdir = os.path.join(tempfile.gettempdir(), '.myqr')
     
     try:
         if not os.path.exists(tempdir):


### PR DESCRIPTION
- Fixed: Change 'os.path.expanduser' func to 'tempfile.gettempdir' func for create the temp dir.

- Question:
When you install with root, the normal account will be called with the following error:
```
Traceback (most recent call last):
  File "/usr/bin/myqr", line 9, in <module>
    load_entry_point('MyQR==2.3.1', 'console_scripts', 'myqr')()
  File "/usr/lib/python2.7/site-packages/MyQR/terminal.py", line 34, in main
    args.directory
  File "/usr/lib/python2.7/site-packages/MyQR/myqr.py", line 92, in run
    os.makedirs(tempdir)
  File "/usr/lib64/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 13] Permission denied: '/root/.myqr'
```
- Location:
os.path.expanduser('~')：the value i get in my Linux system is *root*，so i try to fix it!
I don't know much about python, so i am not sure this is a bug!
